### PR TITLE
Faz com que o tema crie as páginas base do template

### DIFF
--- a/includes/fullstack-admin.php
+++ b/includes/fullstack-admin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace FUllstack;
 
 require_once dirname(dirname(__FILE__)) . "/includes/fullstack-interface.php";
@@ -32,7 +33,7 @@ class FullstackAdminSettings implements FullstackInterface
                 </li>
             </ul>
         </div>
-    <?php }
+<?php }
 
     public function create_projects_post_type()
     {
@@ -76,6 +77,49 @@ class FullstackAdminSettings implements FullstackInterface
 
         if (!post_type_exists('projects')) {
             register_post_type('projects', $args);
+        }
+    }
+
+    public function create_page(string $pageTitle)
+    {
+        $page = array(
+            'post_title'    => $pageTitle,
+            'post_content'  => '',
+            'post_status'   => 'publish',
+            'post_type'     => 'page',
+            'post_name' => strtolower($pageTitle)
+        );
+
+        $post_id = wp_insert_post($page);
+
+        if (!is_wp_error($post_id)) {
+            return $post_id;
+        }
+
+        return false;
+    }
+
+    public function create_theme_pages()
+    {
+        $pages = get_pages();
+        $filteredPages = array();
+
+        $fullstackPages = array(
+            'home',
+            'blog',
+            'projects',
+            'contact',
+            'about'
+        );
+
+        foreach ($pages as $page) {
+            array_push($filteredPages, $page->post_name);
+        }
+
+        foreach ($fullstackPages as $page) {
+            if (!array_search($page, $filteredPages) && $filteredPages[array_search($page, $filteredPages)] !== 'about') {
+                $this->create_page(ucwords($page));
+            }
         }
     }
 }

--- a/includes/fullstack-public.php
+++ b/includes/fullstack-public.php
@@ -39,12 +39,12 @@ class FullstackPublicSettings implements FullstackInterface
             wp_enqueue_script('archive-projects');
         }
 
-        if (get_page_template_slug() === 'page-contact') {
+        if (get_page_template_slug() === 'page-contact' || is_page("contact")) {
             wp_register_script(__('contact', 'fullstack'), get_theme_file_uri() . '/assets/javascript/contact.js', array('jquery'), null, true);
             wp_enqueue_script('contact');
         }
 
-        if (get_page_template_slug() === "page-about") {
+        if (get_page_template_slug() === "page-about" || is_page("about")) {
             wp_register_script('about', get_theme_file_uri() . '/assets/javascript/about.js', array('jquery'), null, true);
             wp_enqueue_script('about');
             wp_register_script('chart_js', 'https://cdn.jsdelivr.net/npm/chart.js', array('jquery'), null, true);
@@ -84,12 +84,12 @@ class FullstackPublicSettings implements FullstackInterface
             wp_enqueue_style('archive-projects');
         }
 
-        if (get_page_template_slug() === 'page-contact') {
+        if (get_page_template_slug() === 'page-contact' || is_page('contact')) {
             wp_register_style('contact', get_theme_file_uri() . '/assets/css/build/contact.css');
             wp_enqueue_style('contact');
         }
 
-        if (get_page_template_slug() === "page-about") {
+        if (get_page_template_slug() === "page-about" || is_page('about')) {
             wp_register_style('about-page', get_theme_file_uri() . '/assets/css/build/about.css');
             wp_enqueue_style('about-page');
         }

--- a/includes/fullstack-settings.php
+++ b/includes/fullstack-settings.php
@@ -11,6 +11,7 @@ class FUllstackSettings {
     public function __construct() {
         $this->public = new FullstackPublicSettings();
         $this->admin = new FullstackAdminSettings();
+        $this->activation_hook();
         $this->action_hooks();
         $this->filter_hooks();
     }
@@ -26,5 +27,9 @@ class FUllstackSettings {
 
     public function filter_hooks() {
         add_filter("script_loader_tag", array($this->public, 'add_public_modules'), 10, 3);
+    }
+
+    public function activation_hook() {
+        add_action('after_switch_theme', array($this->admin, 'create_theme_pages'));
     }
 }


### PR DESCRIPTION
Com esse commit, o tema se torna capaz de criar as páginas:

- home
- about
- contact
- blog
- projects

Quando o usuário muda a configuração de leitura de blog page para páginas estáticas, os templates entram como esperado. No entanto, o template 'single-project-acf' tem precedência sobre 'single-project'. Isso precisa ser resolvido em outra issue.