### PR TITLE
Configura páginas estáticas do tema

### DIFF
--- a/includes/fullstack-admin.php
+++ b/includes/fullstack-admin.php
@@ -122,4 +122,18 @@ class FullstackAdminSettings implements FullstackInterface
             }
         }
     }
+
+    public function theme_reading_settings()
+    {
+        $front_page = get_page_by_path('home');
+        if ($front_page) {
+            update_option('page_on_front', $front_page->ID);
+            update_option('show_on_front', 'page');
+        }
+
+        $blog_page = get_page_by_path('blog');
+        if ($blog_page) {
+            update_option('page_for_posts', $blog_page->ID);
+        }
+    }
 }

--- a/includes/fullstack-settings.php
+++ b/includes/fullstack-settings.php
@@ -31,5 +31,6 @@ class FUllstackSettings {
 
     public function activation_hook() {
         add_action('after_switch_theme', array($this->admin, 'create_theme_pages'));
+        add_action('after_switch_theme', array($this->admin, 'theme_reading_settings'));
     }
 }


### PR DESCRIPTION
Adiciona novo método à classe Admin para configurar a página 'home' como principal e 'blog' como página principal do blog.